### PR TITLE
Set CSV/segwit dates, activate BIP65 and BIP66 with CSV, change bech32 prefix

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -148,7 +148,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
-        bech32_hrp = "bcR";
+        bech32_hrp = "ric";
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
@@ -244,7 +244,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
-        bech32_hrp = "bcr";
+        bech32_hrp = "tric";
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -97,13 +97,13 @@ public:
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1546300800; // January 1st, 2019
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1577836800; // January 1st, 2020
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1479168000; // November 15th, 2016.
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000; // November 15th, 2017.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1546300800; // January 1st, 2019.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1577836800; // January 1st, 2020.
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000093bf63ce15ec087be1cb19337f378"); // 931912
@@ -204,13 +204,13 @@ public:
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1546300800; // January 1st, 2019
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1577836800; // January 1st, 2020
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 14935968000; // May 1st 2017, added a 0
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1546300800; // January 1st, 2019.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1577836800; // January 1st, 2020.
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -82,8 +82,8 @@ public:
         consensus.BIP16Height = 1; // hard coded to always check
         consensus.BIP34Height = 1; // has always been active
         consensus.BIP34Hash = uint256S("78ae9b6ffc008e988a9b052bb331ab49dab0d627c145e3c96ab4b71b2e86a8b5");
-        consensus.BIP65Height = 2000000; // clo1
-        consensus.BIP66Height = 2000000; // clo1
+        consensus.BIP65Height = 9999999;  // Riecoin TODO: Set height to CSV BIP9 activation height
+        consensus.BIP66Height = 9999999;  // Riecoin TODO: Set height to CSV BIP9 activation height
         consensus.powLimit = ArithToUint256(MinPrimeSize);
         consensus.nPowTargetTimespan = 12 * 60 * 60; // 12 hours
         consensus.nPowTargetSpacing = 2.5 * 60;
@@ -189,8 +189,9 @@ public:
         consensus.BIP16Height = 1; // clo1, hard coded to always check
         consensus.BIP34Height = 1; // clo1, has always been active
         consensus.BIP34Hash = uint256();
-        consensus.BIP65Height = 1000000; // clo1
-        consensus.BIP66Height = 12082; // clo1
+        //consensus.BIP66Height = 12082; // clo1
+        consensus.BIP65Height = 9999999;  // Riecoin TODO: Set height to CSV BIP9 activation height
+        consensus.BIP66Height = 9999999;  // Riecoin TODO: Set height to CSV BIP9 activation height
         consensus.powLimit = ArithToUint256(MinPrimeSize);
         consensus.nPowTargetTimespan = 12 * 60 * 60; // 12 hours
         consensus.nPowTargetSpacing = 2.5 * 60;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1798,12 +1798,16 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consens
 //    }
 
     // Start enforcing the DERSIG (BIP66) rule
-    if (pindex->nHeight >= consensusparams.BIP66Height) {
+    // Riecoin TODO: Deploy BIP66 with CSV BIP9. Remove VersionBitsState() check and set BIP66Height
+    //if (pindex->nHeight >= consensusparams.BIP66Height) {
+    if (VersionBitsState(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_CSV, versionbitscache) == THRESHOLD_ACTIVE) {
         flags |= SCRIPT_VERIFY_DERSIG;
     }
 
     // Start enforcing CHECKLOCKTIMEVERIFY (BIP65) rule
-    if (pindex->nHeight >= consensusparams.BIP65Height) {
+    // Riecoin TODO: Deploy BIP65 with CSV BIP9. Remove VersionBitsState() check and set BIP65Height
+    //if (pindex->nHeight >= consensusparams.BIP65Height) {
+    if (VersionBitsState(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_CSV, versionbitscache) == THRESHOLD_ACTIVE) {
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 


### PR DESCRIPTION
This may be a valid way to activate BIP65 and BIP66.

The change in bech32 prefix is to be more inline with other coins, see:

https://github.com/satoshilabs/slips/blob/master/slip-0173.md